### PR TITLE
Zip output assets with the related entrypoint

### DIFF
--- a/packages/webpack/bin/build.ts
+++ b/packages/webpack/bin/build.ts
@@ -164,8 +164,6 @@ const prep = async () => {
     process.exit(1);
   }
 
-  console.info(JSON.stringify(buildOptions, null, 2));
-
   await compile(buildOptions);
 };
 

--- a/packages/webpack/jest.config.ts
+++ b/packages/webpack/jest.config.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import { getProjectConfig, rootConfig, Config } from '../../jest.shared';
 
 const config: Config.InitialOptions = {

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -44,20 +44,32 @@
     "@types/koa__router": "^8.0.11",
     "@types/lodash": "^4.14.181",
     "@types/node": "^14.18.12",
+    "@types/sharp": "^0.30.2",
     "esbuild": "^0.14.27",
     "jest": "^27.5.1",
     "jest-mock-extended": "^2.0.4",
     "jszip": "^3.7.1",
     "koa": "^2.13.4",
     "lodash": "^4.17.21",
+    "node-loader": "^2.0.0",
     "serverless-http": "^2.7.0",
+    "sharp": "^0.30.4",
+    "tapable": "^2.2.1",
     "ts-jest": "^27.1.3",
+    "ts-node": "^10.7.0",
     "typescript": "^4.6.2",
     "ulid": "^2.3.0",
     "verdaccio": "^5.8.0"
   },
   "peerDependencies": {
-    "@types/node": ">=14.18.12"
+    "@babel/core": "^7.17.5",
+    "@babel/preset-env": "^7.16.11",
+    "@babel/preset-typescript": "^7.16.7",
+    "@babel/runtime-corejs3": "^7.17.2",
+    "@types/node": ">=14.18.12",
+    "babel-loader": "^8.2.3",
+    "core-js": "^3.21.1",
+    "ts-loader": "^9.2.8"
   },
   "dependencies": {
     "@babel/core": "^7.17.5",

--- a/packages/webpack/src/configure.ts
+++ b/packages/webpack/src/configure.ts
@@ -6,6 +6,7 @@ import { loadPatch } from './patches';
 import path from 'path';
 import TerserPlugin from 'terser-webpack-plugin';
 import { createRules } from './rules';
+import { ZipAssetsPlugin } from './zipAssetsPlugin';
 import { PatchPnpResolver } from './patchPnpResolver';
 
 const WEBPACK_DEFAULTS = webpackConfig.getNormalizedWebpackOptions({});
@@ -29,6 +30,7 @@ export const createConfiguration = async (config: Config): Promise<ConfigureResu
     enableDnsRetry,
     outputPath = process.cwd(),
     minify,
+    zip,
   } = config;
   const entries = await getEntries(entrypoint, enableRuntimeSourceMaps);
   const plugins: Configuration['plugins'] = [
@@ -42,6 +44,9 @@ export const createConfiguration = async (config: Config): Promise<ConfigureResu
 
   if (enableDnsRetry) {
     plugins.push(await loadPatch('dns'));
+  }
+  if (zip) {
+    plugins.push(new ZipAssetsPlugin());
   }
 
   const outputDir = path.resolve(outputPath);

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -3,7 +3,7 @@ import {
   Stats,
 } from 'webpack';
 
-import { handleWebpackResults, zipOutputFiles } from './utils';
+import { handleWebpackResults } from './utils';
 import { Config } from './types';
 import { createConfiguration } from './configure';
 
@@ -12,7 +12,7 @@ export * from './types';
 export const compile = async (
   config: Config,
 ) => {
-  const { webpackConfig, outputDir, entries } = await createConfiguration(config);
+  const { webpackConfig } = await createConfiguration(config);
   const webpackResult = await new Promise<Stats | undefined>((resolve, reject) => {
     webpack(webpackConfig, (err, stats) => {
       if (err) {
@@ -24,10 +24,6 @@ export const compile = async (
   });
 
   handleWebpackResults(webpackResult);
-
-  if (config.zip) {
-    await zipOutputFiles(outputDir, Object.keys(entries));
-  }
 
   return webpackResult;
 };

--- a/packages/webpack/src/utils.ts
+++ b/packages/webpack/src/utils.ts
@@ -1,9 +1,3 @@
-import path from 'path';
-import archiver from 'archiver';
-import rawGlob from 'glob';
-import { promisify } from 'util';
-import chalk from 'chalk';
-import { promises as fs, createWriteStream } from 'fs';
 import { Stats } from 'webpack';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -11,80 +5,7 @@ const supportsColor = require('supports-color');
 
 import { logging } from '@lifeomic/test-tool-utils';
 
-const glob = promisify(rawGlob);
-
 export const logger = logging.getLogger('lifeomic-webpack');
-
-export interface Entry {
-  file: string;
-  name: string;
-}
-
-/**
- * Helper function to trim absolute file path by removing the `process.cwd()`
- * prefix if file is nested under `process.cwd()`.
- */
-export const makeFilePathRelativeToCwd = (file: string) => {
-  const cwd = process.cwd();
-  return (file.startsWith(cwd)) ? '.' + file.substring(cwd.length) : file;
-};
-
-/**
- * @param {String} outputDir the directory that contains output files
- * @param {String[]} entryNames the entrypoint names from which output was produced
- */
-export const zipOutputFiles = async (outputDir: string, entryNames: string[]) => {
-  logger.info('\nCreating zip file for each entrypoint...\n');
-
-  await Promise.all(entryNames.map(async (entryName) => {
-    const dirname = path.dirname(entryName);
-    const outputZipBasename = `${entryName}.zip`;
-    const outputZipFile = path.join(outputDir, outputZipBasename);
-
-    // Find all the output files that belong to this entry
-    const entriesForZipFile = (await glob(`${entryName}*`, {
-      cwd: outputDir,
-      // ignore previously output zip file for repeatability
-      ignore: outputZipBasename,
-    })).map((file) => ({
-      name: (dirname === '.') ? file : file.substring(dirname.length + 1),
-      file: path.join(outputDir, file),
-    }));
-
-    // Now, write a zip file for each entry
-    logger.info(`Creating zip for entrypoint ${chalk.bold(entryName)}...`);
-    logger.info(entriesForZipFile.map((entry) => `- ${chalk.bold(entry.name)}\n`).join(''));
-    await zip(outputZipFile, entriesForZipFile);
-    logger.info(chalk.green(`Zip file for ${chalk.bold(entryName)} written to ` +
-      `${chalk.bold(makeFilePathRelativeToCwd(outputZipFile))}\n`));
-  }));
-};
-
-const zip = async (zipFile: string, entries: Entry[]) => {
-  await fs.mkdir(path.dirname(zipFile), { recursive: true });
-
-  return new Promise((resolve, reject) => {
-    const outStream = createWriteStream(zipFile);
-    const archive = archiver('zip', {
-      zlib: { level: 9 }, // Sets the compression level.
-    });
-
-    outStream.on('finish', resolve);
-
-    // it is a good practice to catch warnings (ie stat failures and other non-blocking errors)
-    archive.on('warning', reject);
-    archive.on('error', reject);
-
-    for (const entry of entries) {
-      archive.file(entry.file, { name: entry.name });
-    }
-
-    // pipe archive data to the file
-    archive.pipe(outStream);
-
-    void archive.finalize();
-  });
-};
 
 export const handleWebpackResults = (webpackResult?: Stats) => {
   if (!webpackResult) {

--- a/packages/webpack/src/zipAssetsPlugin.ts
+++ b/packages/webpack/src/zipAssetsPlugin.ts
@@ -1,0 +1,126 @@
+import path from 'path';
+import chalk from 'chalk';
+import rawGlob from 'glob';
+import { promisify } from 'util';
+import archiver from 'archiver';
+import { createWriteStream, promises as fs } from 'fs';
+import { WebpackPluginInstance, Compiler, Stats } from 'webpack';
+
+export type WebpackLogger = ReturnType<Compiler['getInfrastructureLogger']>;
+
+export interface Entry {
+  file: string;
+  name: string;
+}
+
+const glob = promisify(rawGlob);
+const pluginName = '@lifeomic/compile-tools-webpack-zip-asset-plugin';
+
+/**
+ * Helper function to trim absolute file path by removing the `process.cwd()`
+ * prefix if file is nested under `process.cwd()`.
+ */
+export const makeFilePathRelativeToCwd = (file: string) => {
+  const cwd = process.cwd();
+  return (file.startsWith(cwd)) ? '.' + file.substring(cwd.length) : file;
+};
+
+const zip = async (zipFile: string, entries: Entry[]) => {
+  await fs.mkdir(path.dirname(zipFile), { recursive: true });
+
+  return new Promise((resolve, reject) => {
+    const outStream = createWriteStream(zipFile);
+    const archive = archiver('zip', {
+      zlib: { level: 9 }, // Sets the compression level.
+    });
+
+    outStream.on('finish', resolve);
+
+    // it is a good practice to catch warnings (ie stat failures and other non-blocking errors)
+    archive.on('warning', reject);
+    archive.on('error', reject);
+
+    for (const entry of entries) {
+      archive.file(entry.file, { name: entry.name });
+    }
+
+    // pipe archive data to the file
+    archive.pipe(outStream);
+
+    void archive.finalize();
+  });
+};
+
+export const zipOutputFiles = async (
+  logger: WebpackLogger,
+  outputDir: string,
+  resources: Record<string, string[]>,
+) => {
+  logger.info('\nCreating zip file for each entrypoint...\n');
+
+  await Promise.all(Object.entries(resources).map(async ([entryName, assets]) => {
+    const dirname = path.dirname(entryName);
+    const outputZipBasename = `${entryName}.zip`;
+    const outputZipFile = path.join(outputDir, outputZipBasename);
+
+    // Find all the output files that belong to this entry
+    const globFiles = await glob(`${entryName}*`, {
+      cwd: outputDir,
+      // ignore previously output zip file for repeatability
+      ignore: outputZipBasename,
+    });
+
+    const entriesForZipFile = [...new Set([...globFiles, ...assets])].map((file) => ({
+      name: (dirname === '.') ? file : file.substring(dirname.length + 1),
+      file: path.join(outputDir, file),
+    }));
+
+    // Now, write a zip file for each entry
+    logger.info(`Creating zip for entrypoint ${chalk.bold(entryName)}...`);
+    logger.info(entriesForZipFile.map(({ name }) => `- ${chalk.bold(name)}\n`).join(''));
+    await zip(outputZipFile, entriesForZipFile);
+    logger.info(chalk.green(`Zip file for ${chalk.bold(entryName)} written to ` +
+      `${chalk.bold(makeFilePathRelativeToCwd(outputZipFile))}\n`));
+  }));
+};
+
+export const processStats = async (
+  logger: WebpackLogger,
+  {
+    compilation: {
+      errors,
+      entrypoints,
+      outputOptions: {
+        path: outputDir = process.cwd(),
+      },
+    },
+  }: Stats,
+) => {
+  logger.info(`ZipAssetsPlugin: outputDir: ${chalk.bold(outputDir)} entrypoints: [${
+    [...entrypoints.keys()].map((name) => chalk.bold(name)).join(', ')
+  }]`);
+
+  if (errors.length) {
+    logger.warn('ZipAssetsPlugin: Not running because of errors');
+    return;
+  }
+
+  const resources: Record<string, string[]> = {};
+  for (const [name, entrypoint] of entrypoints) {
+    const filesToBundle: string[] = [];
+    entrypoint.chunks.forEach(({ files, auxiliaryFiles }) => {
+      filesToBundle.push(...files);
+      filesToBundle.push(...auxiliaryFiles);
+    });
+    resources[name] = filesToBundle;
+  }
+
+  await zipOutputFiles(logger, outputDir, resources);
+};
+
+export class ZipAssetsPlugin implements WebpackPluginInstance {
+  apply(compiler: Compiler) {
+    const logger = compiler.getInfrastructureLogger(pluginName);
+    compiler.hooks.done.tapPromise(pluginName, (stats) => processStats(logger, stats));
+  }
+}

--- a/packages/webpack/test/helpers.ts
+++ b/packages/webpack/test/helpers.ts
@@ -1,3 +1,0 @@
-export const testProject1Directory = `${__dirname}/testProject1`;
-export const buildDirectory = `${testProject1Directory}/build`;
-export const supportedNodeVersions = ['12.20.0', '14.19.0'];

--- a/packages/webpack/test/integration/setup.sh
+++ b/packages/webpack/test/integration/setup.sh
@@ -49,3 +49,4 @@ function installYarnProject () {
 
 (installNpmProject testProject1)
 (installNpmProject testProject2)
+(installYarnProject testProject3)

--- a/packages/webpack/test/integration/test/utils.ts
+++ b/packages/webpack/test/integration/test/utils.ts
@@ -1,29 +1,33 @@
 import { SpawnSyncReturns } from 'child_process';
-import { logging } from '@lifeomic/test-tool-utils';
 import { testProject1DirName } from '../../testProject1';
 import { testProject2DirName } from '../../testProject2';
+import { testProject3DirName } from '../../testProject3';
 import * as path from 'path';
-
-export const logger = logging.getLogger('integration-test');
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 export const tmpProjectDir = process.env.INTEGRATION_TEST_TMP_DIR!;
 
 export const tmpTestProject1Dir = path.join(tmpProjectDir, testProject1DirName);
 export const tmpTestProject2Dir = path.join(tmpProjectDir, testProject2DirName);
+export const tmpTestProject3Dir = path.join(tmpProjectDir, testProject3DirName);
 
-export const handleSpawnResults = (results: SpawnSyncReturns<string | Buffer>) => {
-  if (results.stdout.length) {
-    logger.debug(Buffer.from(results.stdout).toString('utf-8'));
-  }
-  if (results.stderr.length) {
-    logger.debug(Buffer.from(results.stderr).toString('utf-8'));
-  }
-  if (results.status !== 0) {
-    logger.error(Buffer.from(results.stdout).toString('utf-8'));
-    logger.error(Buffer.from(results.stderr).toString('utf-8'));
+export const handleSpawnResults = (
+  {
+    status,
+    ...result
+  }: SpawnSyncReturns<string | Buffer>,
+) => {
+  const stdout = result.stdout || '';
+  const stderr = result.stderr || '';
+  if (status !== 0) {
+    if (stdout) {
+      console.error(Buffer.from(stdout).toString('utf-8'));
+    }
+    if (stderr) {
+      console.error(Buffer.from(stderr).toString('utf-8'));
+    }
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    throw new Error(`Process exited with status ${results.status}`);
+    throw new Error(`Process exited with status ${status}`);
   }
 };
 

--- a/packages/webpack/test/shared/projects.ts
+++ b/packages/webpack/test/shared/projects.ts
@@ -1,8 +1,10 @@
 import { join } from 'path';
 import { Project1Lambdas, testProject1Dir } from '../testProject1';
+import { Project2Lambdas } from '../testProject2';
+import { Project3Lambdas } from '../testProject3';
 
 export interface GetServiceLambdaFile {
-  lambda: Project1Lambdas;
+  lambda: Project1Lambdas | Project2Lambdas | Project3Lambdas;
   ext?: 'js' | 'ts';
   projectDir?: string;
 }

--- a/packages/webpack/test/testProject3/.gitignore
+++ b/packages/webpack/test/testProject3/.gitignore
@@ -1,0 +1,3 @@
+build
+!*.js
+!dirIndex/index.js/

--- a/packages/webpack/test/testProject3/.yarnrc.yml
+++ b/packages/webpack/test/testProject3/.yarnrc.yml
@@ -1,0 +1,1 @@
+enableMirror: false

--- a/packages/webpack/test/testProject3/index.ts
+++ b/packages/webpack/test/testProject3/index.ts
@@ -1,0 +1,6 @@
+export const testProject3ir = __dirname;
+export const testProject3DirName = 'testProject3' as const;
+
+export enum Project3Lambdas {
+  lambdaService= 'lambda_service',
+}

--- a/packages/webpack/test/testProject3/lambdas/lambda_service.js
+++ b/packages/webpack/test/testProject3/lambdas/lambda_service.js
@@ -1,0 +1,17 @@
+const Koa = require('koa');
+const Router = require('@koa/router');
+const serverless = require('serverless-http');
+
+const app = new Koa();
+const router = new Router();
+
+router.get('/', async (context, next) => {
+  context.response.body = {
+    service: 'lambda-test',
+    parameter: process.env.TEST_PARAMETER,
+  };
+  await next();
+});
+
+app.use(router.routes());
+module.exports.handler = serverless(app);

--- a/packages/webpack/test/testProject3/lifeomic-webpack.config.ts
+++ b/packages/webpack/test/testProject3/lifeomic-webpack.config.ts
@@ -1,0 +1,12 @@
+import { Config } from '@lifeomic/compile-tool-webpack';
+
+export const configTransformer: Config['configTransformer'] = (config) => {
+  config.module?.rules?.push({
+    test: /\.node$/,
+    loader: 'node-loader',
+    options: {
+      name: 'node-file-[contentHash].[ext]',
+    },
+  });
+  return config;
+};

--- a/packages/webpack/test/testProject3/package.json
+++ b/packages/webpack/test/testProject3/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "service-test",
+  "private": true,
+  "engines": {
+    "node": ">=14.14.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.17.5",
+    "@babel/preset-env": "^7.16.11",
+    "@babel/preset-typescript": "^7.16.7",
+    "@babel/runtime-corejs3": "^7.17.2",
+    "@types/node": "^14",
+    "@lifeomic/compile-tool-webpack": "intTest",
+    "babel-loader": "^8.2.3",
+    "core-js": "^3.21.1",
+    "node-loader": "^2.0.0",
+    "ts-loader": "^9.2.8",
+    "ts-node": "^10.7.0",
+    "typescript": "^4.6.4"
+  },
+  "dependencies": {
+    "@koa/router": "^10.1.1",
+    "koa": "^2.13.4",
+    "serverless-http": "^2.7.0",
+    "sharp": "^0.30.4"
+  }
+}

--- a/packages/webpack/test/testProject3/sharp.ts
+++ b/packages/webpack/test/testProject3/sharp.ts
@@ -1,0 +1,16 @@
+import sharp from 'sharp';
+import * as fs from 'fs';
+import * as stream from 'stream';
+import { promisify } from 'util';
+
+const pipeline = promisify(stream.pipeline);
+
+const resize = async () => {
+  const inStream = fs.createReadStream('fakePath/to.jpg');
+  const transform = sharp().resize({ width: 100, height: 100 });
+  const outStream = fs.createWriteStream('fakePath/to/output.jpg');
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  await pipeline(inStream, transform, outStream);
+};
+
+resize().catch((e) => console.error(e));

--- a/packages/webpack/test/testProject3/tsconfig.json
+++ b/packages/webpack/test/testProject3/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2021"],
+    "types": ["node"]
+  }
+}

--- a/packages/webpack/test/unit/index.test.ts
+++ b/packages/webpack/test/unit/index.test.ts
@@ -19,7 +19,7 @@ jest.mock('webpack', () => ({
 
 const { webpack } = allWebpack as MockProxy<typeof allWebpack>;
 const { createConfiguration } = rawConfig as MockProxy<typeof rawConfig>;
-const { handleWebpackResults, zipOutputFiles } = rawUtils as MockProxy<typeof rawUtils>;
+const { handleWebpackResults } = rawUtils as MockProxy<typeof rawUtils>;
 
 const setupEnv = (error?: Error) => {
   const webpackResult = mock<Stats>();
@@ -55,16 +55,6 @@ test('will orchestrate a build, and return result', async () => {
     .toBe(webpackResult);
 
   expect(handleWebpackResults).toBeCalledWith(webpackResult);
-  expect(zipOutputFiles).not.toBeCalled();
-});
-
-test('will zip results', async () => {
-  const { webpackResult, entries } = setupEnv();
-  await expect(compile({ entrypoint: getLambdaFile({ lambda: Project1Lambdas.lambdaService }), zip: true })).resolves
-    .toBe(webpackResult);
-
-  expect(handleWebpackResults).toBeCalledWith(webpackResult);
-  expect(zipOutputFiles).toBeCalledWith(__dirname, Object.keys(entries));
 });
 
 test('will throw webpack exceptions', async () => {

--- a/packages/webpack/test/unit/utils.test.ts
+++ b/packages/webpack/test/unit/utils.test.ts
@@ -1,19 +1,16 @@
 import type { Stats } from 'webpack';
 import { mock } from 'jest-mock-extended';
 import { ulid } from 'ulid';
-import { join, basename, relative } from 'path';
+import path from 'path';
 import { promises as fs } from 'fs';
-import JSZip from 'jszip';
 
-import { handleWebpackResults, logger, makeFilePathRelativeToCwd, zipOutputFiles } from '../../src/utils';
-import { testProject1Dir } from '../testProject1';
-import { copyRecursive } from './helpers';
+import { handleWebpackResults, logger } from '../../src/utils';
 
 let testBuildDir: string;
 
 beforeEach(async () => {
   jest.spyOn(logger, 'info').mockReturnValue();
-  testBuildDir = join(__dirname, 'build', ulid());
+  testBuildDir = path.join(__dirname, 'build', ulid());
   await fs.mkdir(testBuildDir, { recursive: true });
 });
 
@@ -51,30 +48,3 @@ describe('handleWebpackResults', () => {
     });
   });
 });
-
-test('will return non cwd full file path', () => {
-  const file = '/dir/to/file.js';
-  expect(makeFilePathRelativeToCwd(file)).toBe(file);
-});
-
-test('will return the relative portion of the path', () => {
-  const expected = `./${relative(process.cwd(), __filename)}`;
-  expect(makeFilePathRelativeToCwd(__filename)).toBe(expected);
-});
-
-test('zipOutputFiles will zip files for us', async () => {
-  await copyRecursive(join(testProject1Dir, 'zip'), testBuildDir);
-  const entries = ['first.js', 'second.js', 'third/third.js'];
-  await expect(zipOutputFiles(testBuildDir, entries)).resolves.not.toThrow();
-  await Promise.all(entries.map(async (name) => {
-    const zip = new JSZip();
-    const zipFileName = join(testBuildDir, `${name}.zip`);
-    await expect(fs.stat(zipFileName)).resolves.not.toThrow();
-    await zip.loadAsync(await fs.readFile(zipFileName));
-    expect(zip.file(basename(name))).not.toBeNull();
-    if (name === 'second.js') {
-      expect(zip.file(`${name}.png`)).not.toBeNull();
-    }
-  }));
-});
-

--- a/packages/webpack/test/unit/zipAssetsPlugin.test.ts
+++ b/packages/webpack/test/unit/zipAssetsPlugin.test.ts
@@ -1,0 +1,131 @@
+import path from 'path';
+import chalk from 'chalk';
+import JSZip from 'jszip';
+import rawGlob from 'glob';
+import { ulid } from 'ulid';
+import { promisify } from 'util';
+import { promises as fs } from 'fs';
+import { AsyncSeriesHook } from 'tapable';
+import { basename, join, relative } from 'path';
+import { Compiler, Stats, WebpackError } from 'webpack';
+import { mock, mockFn, mockDeep } from 'jest-mock-extended';
+
+import { compile, Config } from '../../src';
+import {
+  ZipAssetsPlugin,
+  zipOutputFiles,
+  WebpackLogger,
+  processStats,
+  makeFilePathRelativeToCwd,
+} from '../../src/zipAssetsPlugin';
+
+import { copyRecursive } from './helpers';
+import { testProject1Dir } from '../testProject1';
+import { testProject3ir } from '../testProject3';
+
+const glob = promisify(rawGlob);
+
+const logger = mockDeep<WebpackLogger>();
+
+let testBuildDir: string;
+
+beforeEach(async () => {
+  testBuildDir = join(__dirname, 'build', ulid());
+  await fs.mkdir(testBuildDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.rm(testBuildDir, { recursive: true, force: true });
+});
+
+test('will return non cwd full file path', () => {
+  const file = '/dir/to/file.js';
+  expect(makeFilePathRelativeToCwd(file)).toBe(file);
+});
+
+test('will return the relative portion of the path', () => {
+  const expected = `./${relative(process.cwd(), __filename)}`;
+  expect(makeFilePathRelativeToCwd(__filename)).toBe(expected);
+});
+
+test('zipOutputFiles will zip files for us', async () => {
+  await copyRecursive(join(testProject1Dir, 'zip'), testBuildDir);
+  const entries = ['first.js', 'second.js', 'third/third.js'];
+  await expect(zipOutputFiles(logger, testBuildDir, entries.reduce((acc, entryName) => ({ ...acc, [entryName]: [entryName] }), {}))).resolves.not.toThrow();
+  await Promise.all(entries.map(async (name) => {
+    const zip = new JSZip();
+    const zipFileName = join(testBuildDir, `${name}.zip`);
+    await expect(fs.stat(zipFileName)).resolves.not.toThrow();
+    await zip.loadAsync(await fs.readFile(zipFileName));
+    expect(zip.file(basename(name))).not.toBeNull();
+    if (name === 'second.js') {
+      expect(zip.file(`${name}.png`)).not.toBeNull();
+    }
+  }));
+});
+
+test('will zip output files', async () => {
+  const config: Config = {
+    outputPath: testBuildDir,
+    entrypoint: path.join(testProject3ir, 'sharp.ts'),
+    zip: true,
+    configTransformer: (config) => {
+      config.module!.rules!.push({
+        test: /\.node$/,
+        loader: 'node-loader',
+        options: {
+          name: 'node-file-[contentHash].[ext]',
+        },
+      });
+      return config;
+    },
+  };
+
+  const results = await compile(config);
+  expect(results).not.toBeUndefined();
+  const files = await glob(path.join(testBuildDir, 'node-file-*.node'));
+
+  const zip = new JSZip();
+  const zipFileName = join(testBuildDir, 'sharp.js.zip');
+  await expect(fs.stat(zipFileName)).resolves.not.toThrow();
+  await zip.loadAsync(await fs.readFile(zipFileName));
+  expect(zip.file('sharp.js')).not.toBeNull();
+  files.forEach((file) => {
+    const relativeName = path.relative(testBuildDir, file);
+    expect(zip.file(relativeName)).not.toBeNull();
+  });
+}, 30e3);
+
+test('will not run when errors', async () => {
+  const stats = mock<Stats>();
+  const compilation = mock<Stats['compilation']>();
+  stats.compilation = compilation;
+  compilation.errors = [mock<WebpackError>()];
+  const entrypoints: Stats['compilation']['entrypoints'] = new Map();
+  compilation.entrypoints = entrypoints;
+  entrypoints.set(ulid(), mock());
+
+  await expect(processStats(logger, stats)).resolves.not.toThrow();
+
+  expect(logger.info).toBeCalledWith(
+    `ZipAssetsPlugin: outputDir: ${chalk.bold(process.cwd())} entrypoints: [${
+      [...entrypoints.keys()].map((name) => chalk.bold(name)).join(', ')}]`,
+  );
+  expect(logger.warn).toBeCalledWith('ZipAssetsPlugin: Not running because of errors');
+});
+
+test('will set up to process stats', () => {
+  const compiler = mock<Compiler>();
+  compiler.hooks = mock();
+
+  const tapPromise = mockFn<AsyncSeriesHook<[Stats]>['tapPromise']>();
+  compiler.hooks.done.tapPromise = tapPromise;
+
+  compiler.getInfrastructureLogger.mockReturnValue(logger);
+
+  const plugin = new ZipAssetsPlugin();
+  plugin.apply(compiler);
+
+  expect(compiler.getInfrastructureLogger).toBeCalledWith('@lifeomic/compile-tools-webpack-zip-asset-plugin');
+  expect(tapPromise).toBeCalledWith('@lifeomic/compile-tools-webpack-zip-asset-plugin', expect.any(Function));
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2456,6 +2456,7 @@ __metadata:
     "@types/lodash": ^4.14.181
     "@types/nested-error-stacks": ^2.1.0
     "@types/node": ^14.18.12
+    "@types/sharp": ^0.30.2
     "@types/webpack-sources": ^3.2.0
     "@types/yargs": ^17.0.10
     archiver: ^5.3.0
@@ -2471,13 +2472,17 @@ __metadata:
     jszip: ^3.7.1
     koa: ^2.13.4
     lodash: ^4.17.21
+    node-loader: ^2.0.0
     regenerator-runtime: ^0.13.9
     serverless-http: ^2.7.0
+    sharp: ^0.30.4
     source-map-support: ^0.5.21
     supports-color: ^8.1.1
+    tapable: ^2.2.1
     terser-webpack-plugin: ^5.3.1
     ts-jest: ^27.1.3
     ts-loader: ^9.2.8
+    ts-node: ^10.7.0
     typescript: ^4.6.2
     ulid: ^2.3.0
     verdaccio: ^5.8.0
@@ -2487,7 +2492,14 @@ __metadata:
     yargs: ^17.3.1
     zip-webpack-plugin: ^4.0.1
   peerDependencies:
+    "@babel/core": ^7.17.5
+    "@babel/preset-env": ^7.16.11
+    "@babel/preset-typescript": ^7.16.7
+    "@babel/runtime-corejs3": ^7.17.2
     "@types/node": ">=14.18.12"
+    babel-loader: ^8.2.3
+    core-js: ^3.21.1
+    ts-loader: ^9.2.8
   bin:
     lifeomic-webpack: ./bin/build.js
   languageName: unknown
@@ -3817,6 +3829,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/sharp@npm:^0.30.2":
+  version: 0.30.2
+  resolution: "@types/sharp@npm:0.30.2"
+  dependencies:
+    "@types/node": "*"
+  checksum: dc6b332c309e1eb62e98b62f92829c4b06c3adb474c1ee8b504eb95e6d43be8804b8d541874d0769160595fdf46f7a7a0fe544a3659482ad0a19ac700944f3a4
+  languageName: node
+  linkType: hard
+
 "@types/source-list-map@npm:*":
   version: 0.1.2
   resolution: "@types/source-list-map@npm:0.1.2"
@@ -4480,6 +4501,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "ansi-regex@npm:2.1.1"
+  checksum: 190abd03e4ff86794f338a31795d262c1dfe8c91f7e01d04f13f646f1dcb16c5800818f886047876f1272f065570ab86b24b99089f8b68a0e11ff19aed4ca8f1
+  languageName: node
+  linkType: hard
+
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -4543,6 +4571,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aproba@npm:^1.0.3":
+  version: 1.2.0
+  resolution: "aproba@npm:1.2.0"
+  checksum: 0fca141966559d195072ed047658b6e6c4fe92428c385dd38e288eacfc55807e7b4989322f030faff32c0f46bb0bc10f1e0ac32ec22d25315a1e5bbc0ebb76dc
+  languageName: node
+  linkType: hard
+
 "aproba@npm:^1.0.3 || ^2.0.0, aproba@npm:^2.0.0":
   version: 2.0.0
   resolution: "aproba@npm:2.0.0"
@@ -4597,6 +4632,16 @@ __metadata:
     delegates: ^1.0.0
     readable-stream: ^3.6.0
   checksum: 348edfdd931b0b50868b55402c01c3f64df1d4c229ab6f063539a5025fd6c5f5bb8a0cab409bbed8d75d34762d22aa91b7c20b4204eb8177063158d9ba792981
+  languageName: node
+  linkType: hard
+
+"are-we-there-yet@npm:~1.1.2":
+  version: 1.1.7
+  resolution: "are-we-there-yet@npm:1.1.7"
+  dependencies:
+    delegates: ^1.0.0
+    readable-stream: ^2.0.6
+  checksum: 70d251719c969b2745bfe5ddf3ebaefa846a636e90a6d5212573676af5d6670e15457761d4725731e19cbebdce42c4ab0cbedf23ab047f2a08274985aa10a3c7
   languageName: node
   linkType: hard
 
@@ -5437,6 +5482,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"code-point-at@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "code-point-at@npm:1.1.0"
+  checksum: 17d5666611f9b16d64fdf48176d9b7fb1c7d1c1607a189f7e600040a11a6616982876af148230336adb7d8fe728a559f743a4e29db3747e3b1a32fa7f4529681
+  languageName: node
+  linkType: hard
+
 "collect-v8-coverage@npm:^1.0.0":
   version: 1.0.1
   resolution: "collect-v8-coverage@npm:1.0.1"
@@ -5469,10 +5521,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:~1.1.4":
+"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
+  languageName: node
+  linkType: hard
+
+"color-string@npm:^1.9.0":
+  version: 1.9.1
+  resolution: "color-string@npm:1.9.1"
+  dependencies:
+    color-name: ^1.0.0
+    simple-swizzle: ^0.2.2
+  checksum: c13fe7cff7885f603f49105827d621ce87f4571d78ba28ef4a3f1a104304748f620615e6bf065ecd2145d0d9dad83a3553f52bb25ede7239d18e9f81622f1cc5
   languageName: node
   linkType: hard
 
@@ -5482,6 +5544,16 @@ __metadata:
   bin:
     color-support: bin.js
   checksum: 9b7356817670b9a13a26ca5af1c21615463b500783b739b7634a0c2047c16cef4b2865d7576875c31c3cddf9dd621fa19285e628f20198b233a5cfdda6d0793b
+  languageName: node
+  linkType: hard
+
+"color@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "color@npm:4.2.3"
+  dependencies:
+    color-convert: ^2.0.1
+    color-string: ^1.9.0
+  checksum: 0579629c02c631b426780038da929cca8e8d80a40158b09811a0112a107c62e10e4aad719843b791b1e658ab4e800558f2e87ca4522c8b32349d497ecb6adeb4
   languageName: node
   linkType: hard
 
@@ -5625,7 +5697,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"console-control-strings@npm:^1.1.0":
+"console-control-strings@npm:^1.0.0, console-control-strings@npm:^1.1.0, console-control-strings@npm:~1.1.0":
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
   checksum: 8755d76787f94e6cf79ce4666f0c5519906d7f5b02d4b884cf41e11dcd759ed69c57da0670afd9236d229a46e0f9cf519db0cd829c6dca820bb5a5c3def584ed
@@ -6039,6 +6111,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decompress-response@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "decompress-response@npm:6.0.0"
+  dependencies:
+    mimic-response: ^3.1.0
+  checksum: d377cf47e02d805e283866c3f50d3d21578b779731e8c5072d6ce8c13cc31493db1c2f6784da9d1d5250822120cefa44f1deab112d5981015f2e17444b763812
+  languageName: node
+  linkType: hard
+
 "dedent@npm:^0.7.0":
   version: 0.7.0
   resolution: "dedent@npm:0.7.0"
@@ -6154,6 +6235,13 @@ __metadata:
   version: 1.0.4
   resolution: "destroy@npm:1.0.4"
   checksum: da9ab4961dc61677c709da0c25ef01733042614453924d65636a7db37308fef8a24cd1e07172e61173d471ca175371295fbc984b0af5b2b4ff47cd57bd784c03
+  languageName: node
+  linkType: hard
+
+"detect-libc@npm:^2.0.0, detect-libc@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "detect-libc@npm:2.0.1"
+  checksum: ccb05fcabbb555beb544d48080179c18523a343face9ee4e1a86605a8715b4169f94d663c21a03c310ac824592f2ba9a5270218819bb411ad7be578a527593d7
   languageName: node
   linkType: hard
 
@@ -7038,6 +7126,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expand-template@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "expand-template@npm:2.0.3"
+  checksum: 588c19847216421ed92befb521767b7018dc88f88b0576df98cb242f20961425e96a92cbece525ef28cc5becceae5d544ae0f5b9b5e2aa05acb13716ca5b3099
+  languageName: node
+  linkType: hard
+
 "expect@npm:^27.5.1":
   version: 27.5.1
   resolution: "expect@npm:27.5.1"
@@ -7513,6 +7608,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gauge@npm:~2.7.3":
+  version: 2.7.4
+  resolution: "gauge@npm:2.7.4"
+  dependencies:
+    aproba: ^1.0.3
+    console-control-strings: ^1.0.0
+    has-unicode: ^2.0.0
+    object-assign: ^4.1.0
+    signal-exit: ^3.0.0
+    string-width: ^1.0.1
+    strip-ansi: ^3.0.1
+    wide-align: ^1.1.0
+  checksum: a89b53cee65579b46832e050b5f3a79a832cc422c190de79c6b8e2e15296ab92faddde6ddf2d376875cbba2b043efa99b9e1ed8124e7365f61b04e3cee9d40ee
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -7572,6 +7683,13 @@ __metadata:
     through2: ~2.0.0
     traverse: ~0.6.6
   checksum: 57294e72f91920d3262ff51fb0fd81dba1465c9e1b25961e19c757ae39bb38e72dd4a5da40649eeb368673b08be449a0844a2bafc0c0ded7375a8a56a6af8640
+  languageName: node
+  linkType: hard
+
+"github-from-package@npm:0.0.0":
+  version: 0.0.0
+  resolution: "github-from-package@npm:0.0.0"
+  checksum: 14e448192a35c1e42efee94c9d01a10f42fe790375891a24b25261246ce9336ab9df5d274585aedd4568f7922246c2a78b8a8cd2571bfe99c693a9718e7dd0e3
   languageName: node
   linkType: hard
 
@@ -7736,7 +7854,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-unicode@npm:^2.0.1":
+"has-unicode@npm:^2.0.0, has-unicode@npm:^2.0.1":
   version: 2.0.1
   resolution: "has-unicode@npm:2.0.1"
   checksum: 1eab07a7436512db0be40a710b29b5dc21fa04880b7f63c9980b706683127e3c1b57cb80ea96d47991bdae2dfe479604f6a1ba410106ee1046a41d1bd0814400
@@ -8107,6 +8225,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-arrayish@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "is-arrayish@npm:0.3.2"
+  checksum: 977e64f54d91c8f169b59afcd80ff19227e9f5c791fa28fa2e5bce355cbaf6c2c356711b734656e80c9dd4a854dd7efcf7894402f1031dfc5de5d620775b4d5f
+  languageName: node
+  linkType: hard
+
 "is-cidr@npm:*":
   version: 4.0.2
   resolution: "is-cidr@npm:4.0.2"
@@ -8129,6 +8254,15 @@ __metadata:
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
   checksum: df033653d06d0eb567461e58a7a8c9f940bd8c22274b94bf7671ab36df5719791aae15eef6d83bbb5e23283967f2f984b8914559d4449efda578c775c4be6f85
+  languageName: node
+  linkType: hard
+
+"is-fullwidth-code-point@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-fullwidth-code-point@npm:1.0.0"
+  dependencies:
+    number-is-nan: ^1.0.0
+  checksum: 4d46a7465a66a8aebcc5340d3b63a56602133874af576a9ca42c6f0f4bd787a743605771c5f246db77da96605fefeffb65fc1dbe862dcc7328f4b4d03edf5a57
   languageName: node
   linkType: hard
 
@@ -9478,6 +9612,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loader-utils@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "loader-utils@npm:2.0.2"
+  dependencies:
+    big.js: ^5.2.2
+    emojis-list: ^3.0.0
+    json5: ^2.1.2
+  checksum: 9078d1ed47cadc57f4c6ddbdb2add324ee7da544cea41de3b7f1128e8108fcd41cd3443a85b7ee8d7d8ac439148aa221922774efe4cf87506d4fb054d5889303
+  languageName: node
+  linkType: hard
+
 "locate-path@npm:^2.0.0":
   version: 2.0.0
   resolution: "locate-path@npm:2.0.0"
@@ -9952,6 +10097,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mimic-response@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "mimic-response@npm:3.1.0"
+  checksum: 25739fee32c17f433626bf19f016df9036b75b3d84a3046c7d156e72ec963dd29d7fc8a302f55a3d6c5a4ff24259676b15d915aad6480815a969ff2ec0836867
+  languageName: node
+  linkType: hard
+
 "min-indent@npm:^1.0.0":
   version: 1.0.1
   resolution: "min-indent@npm:1.0.1"
@@ -9995,7 +10147,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.6":
+"minimist@npm:^1.2.3, minimist@npm:^1.2.6":
   version: 1.2.6
   resolution: "minimist@npm:1.2.6"
   checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb
@@ -10082,7 +10234,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp-classic@npm:^0.5.2":
+"mkdirp-classic@npm:^0.5.2, mkdirp-classic@npm:^0.5.3":
   version: 0.5.3
   resolution: "mkdirp-classic@npm:0.5.3"
   checksum: 3f4e088208270bbcc148d53b73e9a5bd9eef05ad2cbf3b3d0ff8795278d50dd1d11a8ef1875ff5aea3fa888931f95bfcb2ad5b7c1061cfefd6284d199e6776ac
@@ -10182,6 +10334,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"napi-build-utils@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "napi-build-utils@npm:1.0.2"
+  checksum: 06c14271ee966e108d55ae109f340976a9556c8603e888037145d6522726aebe89dd0c861b4b83947feaf6d39e79e08817559e8693deedc2c94e82c5cbd090c7
+  languageName: node
+  linkType: hard
+
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -10250,6 +10409,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-abi@npm:^3.3.0":
+  version: 3.15.0
+  resolution: "node-abi@npm:3.15.0"
+  dependencies:
+    semver: ^7.3.5
+  checksum: 8fb0374d11f4d02beaacfedf5e536006f0c5f4c479cd2ff6cfda39b0a8f1f9230dbac865f80e98f030dae5ae8e197806b8683547dad1b79af16246e32a441e24
+  languageName: node
+  linkType: hard
+
+"node-addon-api@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "node-addon-api@npm:4.3.0"
+  dependencies:
+    node-gyp: latest
+  checksum: 3de396e23cc209f539c704583e8e99c148850226f6e389a641b92e8967953713228109f919765abc1f4355e801e8f41842f96210b8d61c7dcc10a477002dcf00
+  languageName: node
+  linkType: hard
+
 "node-emoji@npm:^1.10.0":
   version: 1.11.0
   resolution: "node-emoji@npm:1.11.0"
@@ -10297,6 +10474,17 @@ __metadata:
   version: 0.4.0
   resolution: "node-int64@npm:0.4.0"
   checksum: d0b30b1ee6d961851c60d5eaa745d30b5c95d94bc0e74b81e5292f7c42a49e3af87f1eb9e89f59456f80645d679202537de751b7d72e9e40ceea40c5e449057e
+  languageName: node
+  linkType: hard
+
+"node-loader@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "node-loader@npm:2.0.0"
+  dependencies:
+    loader-utils: ^2.0.0
+  peerDependencies:
+    webpack: ^5.0.0
+  checksum: 9252a92b226c0e6fdd29fef92d9853d6c389a4c65119a32306dc12cee7886f2ab4dde333dda5e37df92283c34bd0267e98c384be6d548dbe69676e3343f549ea
   languageName: node
   linkType: hard
 
@@ -10561,6 +10749,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npmlog@npm:^4.0.1":
+  version: 4.1.2
+  resolution: "npmlog@npm:4.1.2"
+  dependencies:
+    are-we-there-yet: ~1.1.2
+    console-control-strings: ~1.1.0
+    gauge: ~2.7.3
+    set-blocking: ~2.0.0
+  checksum: edbda9f95ec20957a892de1839afc6fb735054c3accf6fbefe767bac9a639fd5cea2baeac6bd2bcd50a85cb54924d57d9886c81c7fbc2332c2ddd19227504192
+  languageName: node
+  linkType: hard
+
+"number-is-nan@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "number-is-nan@npm:1.0.1"
+  checksum: 13656bc9aa771b96cef209ffca31c31a03b507ca6862ba7c3f638a283560620d723d52e626d57892c7fff475f4c36ac07f0600f14544692ff595abff214b9ffb
+  languageName: node
+  linkType: hard
+
 "nwsapi@npm:^2.2.0":
   version: 2.2.0
   resolution: "nwsapi@npm:2.2.0"
@@ -10575,7 +10782,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^4":
+"object-assign@npm:^4, object-assign@npm:^4.1.0":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
@@ -11084,6 +11291,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prebuild-install@npm:^7.0.1":
+  version: 7.1.0
+  resolution: "prebuild-install@npm:7.1.0"
+  dependencies:
+    detect-libc: ^2.0.0
+    expand-template: ^2.0.3
+    github-from-package: 0.0.0
+    minimist: ^1.2.3
+    mkdirp-classic: ^0.5.3
+    napi-build-utils: ^1.0.1
+    node-abi: ^3.3.0
+    npmlog: ^4.0.1
+    pump: ^3.0.0
+    rc: ^1.2.7
+    simple-get: ^4.0.0
+    tar-fs: ^2.0.0
+    tunnel-agent: ^0.6.0
+  bin:
+    prebuild-install: bin.js
+  checksum: 204f2d89c6d6179fa1039036514aa72f7d0b537e421ef72c40840286e318f41489f00f22c6acc725cce6e10d43825b69dcabeaadfc917db781c58cd56fc25f90
+  languageName: node
+  linkType: hard
+
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
@@ -11382,7 +11612,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc@npm:^1.2.8":
+"rc@npm:^1.2.7, rc@npm:^1.2.8":
   version: 1.2.8
   resolution: "rc@npm:1.2.8"
   dependencies:
@@ -11496,7 +11726,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.5, readable-stream@npm:~2.3.6":
+"readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.5, readable-stream@npm:^2.0.6, readable-stream@npm:~2.3.6":
   version: 2.3.7
   resolution: "readable-stream@npm:2.3.7"
   dependencies:
@@ -12041,6 +12271,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.3.7":
+  version: 7.3.7
+  resolution: "semver@npm:7.3.7"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 2fa3e877568cd6ce769c75c211beaed1f9fce80b28338cadd9d0b6c40f2e2862bafd62c19a6cff42f3d54292b7c623277bcab8816a2b5521cf15210d43e75232
+  languageName: node
+  linkType: hard
+
 "send@npm:0.17.2":
   version: 0.17.2
   resolution: "send@npm:0.17.2"
@@ -12095,7 +12336,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"set-blocking@npm:^2.0.0":
+"set-blocking@npm:^2.0.0, set-blocking@npm:~2.0.0":
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
   checksum: 6e65a05f7cf7ebdf8b7c75b101e18c0b7e3dff4940d480efed8aad3a36a4005140b660fa1d804cb8bce911cac290441dc728084a30504d3516ac2ff7ad607b02
@@ -12116,6 +12357,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sharp@npm:^0.30.4":
+  version: 0.30.4
+  resolution: "sharp@npm:0.30.4"
+  dependencies:
+    color: ^4.2.3
+    detect-libc: ^2.0.1
+    node-addon-api: ^4.3.0
+    node-gyp: latest
+    prebuild-install: ^7.0.1
+    semver: ^7.3.7
+    simple-get: ^4.0.1
+    tar-fs: ^2.1.1
+    tunnel-agent: ^0.6.0
+  checksum: 80070d8cad5fe20e7bbb2a1cfddda3f7d421f6af8302c05af8307c0b3b1972e6ed2690563e90b2897b4b499b32967d28a15e37f5d196a1f8867d630609052211
+  languageName: node
+  linkType: hard
+
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -12132,7 +12390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
+"signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
@@ -12147,6 +12405,33 @@ __metadata:
     figures: ^2.0.0
     pkg-conf: ^2.1.0
   checksum: a6a540e054096a1f4cf8b1f21fea62ca3e44a19faa63bd486723b736348609caab1fa59a87f16559de347dde8ae1fdebfc25a8b6723c88ae8239f176ffb0dda5
+  languageName: node
+  linkType: hard
+
+"simple-concat@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "simple-concat@npm:1.0.1"
+  checksum: 4d211042cc3d73a718c21ac6c4e7d7a0363e184be6a5ad25c8a1502e49df6d0a0253979e3d50dbdd3f60ef6c6c58d756b5d66ac1e05cda9cacd2e9fc59e3876a
+  languageName: node
+  linkType: hard
+
+"simple-get@npm:^4.0.0, simple-get@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "simple-get@npm:4.0.1"
+  dependencies:
+    decompress-response: ^6.0.0
+    once: ^1.3.1
+    simple-concat: ^1.0.0
+  checksum: e4132fd27cf7af230d853fa45c1b8ce900cb430dd0a3c6d3829649fe4f2b26574c803698076c4006450efb0fad2ba8c5455fbb5755d4b0a5ec42d4f12b31d27e
+  languageName: node
+  linkType: hard
+
+"simple-swizzle@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "simple-swizzle@npm:0.2.2"
+  dependencies:
+    is-arrayish: ^0.3.1
+  checksum: a7f3f2ab5c76c4472d5c578df892e857323e452d9f392e1b5cf74b74db66e6294a1e1b8b390b519fa1b96b5b613f2a37db6cffef52c3f1f8f3c5ea64eb2d54c0
   languageName: node
   linkType: hard
 
@@ -12421,6 +12706,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-width@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "string-width@npm:1.0.2"
+  dependencies:
+    code-point-at: ^1.0.0
+    is-fullwidth-code-point: ^1.0.0
+    strip-ansi: ^3.0.0
+  checksum: 5c79439e95bc3bd7233a332c5f5926ab2ee90b23816ed4faa380ce3b2576d7800b0a5bb15ae88ed28737acc7ea06a518c2eef39142dd727adad0e45c776cd37e
+  languageName: node
+  linkType: hard
+
 "string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
@@ -12454,6 +12750,15 @@ __metadata:
   version: 1.0.1
   resolution: "stringify-package@npm:1.0.1"
   checksum: 462036085a0cf7ae073d9b88a2bbf7efb3792e3df3e1fd436851f64196eb0234c8f8ffac436357e355687d6030b7af42e98af9515929e41a6a5c8653aa62a5aa
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^3.0.0, strip-ansi@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "strip-ansi@npm:3.0.1"
+  dependencies:
+    ansi-regex: ^2.0.0
+  checksum: 9b974de611ce5075c70629c00fa98c46144043db92ae17748fb780f706f7a789e9989fd10597b7c2053ae8d1513fd707816a91f1879b2f71e6ac0b6a863db465
   languageName: node
   linkType: hard
 
@@ -12561,10 +12866,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tapable@npm:^2.1.1, tapable@npm:^2.2.0":
+"tapable@npm:^2.1.1, tapable@npm:^2.2.0, tapable@npm:^2.2.1":
   version: 2.2.1
   resolution: "tapable@npm:2.2.1"
   checksum: 3b7a1b4d86fa940aad46d9e73d1e8739335efd4c48322cb37d073eb6f80f5281889bf0320c6d8ffcfa1a0dd5bfdbd0f9d037e252ef972aca595330538aac4d51
+  languageName: node
+  linkType: hard
+
+"tar-fs@npm:^2.0.0, tar-fs@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "tar-fs@npm:2.1.1"
+  dependencies:
+    chownr: ^1.1.1
+    mkdirp-classic: ^0.5.2
+    pump: ^3.0.0
+    tar-stream: ^2.1.4
+  checksum: f5b9a70059f5b2969e65f037b4e4da2daf0fa762d3d232ffd96e819e3f94665dbbbe62f76f084f1acb4dbdcce16c6e4dac08d12ffc6d24b8d76720f4d9cf032d
   languageName: node
   linkType: hard
 
@@ -12580,7 +12897,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-stream@npm:^2.0.0, tar-stream@npm:^2.2.0":
+"tar-stream@npm:^2.0.0, tar-stream@npm:^2.1.4, tar-stream@npm:^2.2.0":
   version: 2.2.0
   resolution: "tar-stream@npm:2.2.0"
   dependencies:
@@ -13702,7 +14019,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wide-align@npm:^1.1.5":
+"wide-align@npm:^1.1.0, wide-align@npm:^1.1.5":
   version: 1.1.5
   resolution: "wide-align@npm:1.1.5"
   dependencies:


### PR DESCRIPTION
![bundle](https://media.giphy.com/media/26Do398gEuMbPtGyQ/giphy-downsized.gif)

If an asset is generated by webpack it won't necessarily be output multiple times for each entrypoint that needs it.  This should handle that by zipping up related assets.  

I would also like to put this out there as a webpack-contrib project, but want to use it sooner.